### PR TITLE
fixed 'delete' button not appearing in goal popup

### DIFF
--- a/js/tree.js
+++ b/js/tree.js
@@ -262,8 +262,8 @@ function showcaseData(data) {
                     li.innerHTML = item;
                     li.setAttribute('aria-label', item);
                     editorFields.appendChild(li);
-                    let deleteBtn = document.createElement('button');
-                    if(field == 'requires' && index != 0) {
+                    if(field == 'requires' || field == 'goal') {
+                        let deleteBtn = document.createElement('button');
                         deleteBtn.innerHTML = 'Delete';
                         deleteBtn.classList.add('btn', 'btn-danger');
                         deleteBtn.addEventListener('click', function () {


### PR DESCRIPTION
Fixed the 'delete' button not getting the text filled in on the goal popup. Also removed the thing about it not applying on the first goal. It was originally made to enforce at least one goal in the list but it is removed now.