### PR TITLE
Fixed the goal button disappearing on new skills

### DIFF
--- a/js/tree.js
+++ b/js/tree.js
@@ -328,8 +328,8 @@ function saveShowcasedNode() {
     let data = structuredClone(findNode(changedTree, id));
     let newData = {};
     newData.id = data.id;
-    newData.requires = data.requires;
-    if(data.goal) newData.goal = data.goal 
+    newData.requires = data.requires || [];
+    newData.goal = data.goal || []
 
     let inputs = document.querySelectorAll('.edit-fields input');
     inputs.forEach(input => {


### PR DESCRIPTION
Goal field would disappear if the user clicked off the skill after creating it without making at least one goal.

This was due to the way it saves it, I fixed the same error for required fields a while back but completely forgot to do it for the goals as well.